### PR TITLE
Include token expiry in login response

### DIFF
--- a/Api/internal/presentation/auth.go
+++ b/Api/internal/presentation/auth.go
@@ -76,12 +76,16 @@ func (handler *AuthHandlers) Login(context *gin.Context) {
 		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	token, err := handler.service.Login(context.Request.Context(), request.Email, request.Password)
+	token, expiresIn, err := handler.service.Login(context.Request.Context(), request.Email, request.Password)
 	if err != nil {
 		context.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 		return
 	}
-	context.JSON(http.StatusOK, gin.H{"token": token})
+	context.JSON(http.StatusOK, gin.H{
+		"token_type":   "Bearer",
+		"expires_in":   expiresIn,
+		"access_token": token,
+	})
 }
 
 func (handler *AuthHandlers) Logout(context *gin.Context) {

--- a/VideoRank API.postman_collection_OK.json
+++ b/VideoRank API.postman_collection_OK.json
@@ -1,179 +1,192 @@
 {
-	"info": {
-		"_postman_id": "b6e32813-0e6a-49df-9a33-26bdf266cf3f",
-		"name": "VideoRank API",
-		"description": "Colección básica para probar autenticación y salud del API de VideoRank.",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "31371962"
-	},
-	"item": [
-		{
-			"name": "Health (status)",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:8080/status",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"status"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Health (health)",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{host}}:{{port}}/health",
-					"host": [
-						"{{host}}"
-					],
-					"port": "{{port}}",
-					"path": [
-						"health"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Auth / Register",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"first_name\": \"Alice\",\n  \"last_name\": \"Tester\",\n  \"email\": \"alice@example.com\",\n  \"password1\": \"Password123!\",\n  \"password2\": \"Password123!\"\n}"
-				},
-				"url": {
-					"raw": "{{host}}:{{port}}/api/auth/signup",
-					"host": [
-						"{{host}}"
-					],
-					"port": "{{port}}",
-					"path": [
-						"api",
-						"auth",
-						"signup"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Auth / Login",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"// Guarda el token JWT en la variable de entorno 'jwt' si viene como { token: \"...\" }",
-							"try {",
-							"  const data = pm.response.json();",
-							"  const token = data.token || data.access_token || data.jwt;",
-							"  if (token) {",
-							"    pm.environment.set('jwt', token);",
-							"    console.log('JWT guardado en entorno');",
-							"  } else {",
-							"    console.warn('No se encontró token en la respuesta');",
-							"  }",
-							"} catch(e) {",
-							"  console.error('No JSON o error parseando respuesta');",
-							"}"
-						],
-						"type": "text/javascript",
-						"packages": {}
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \n  \"email\": \"alice@example.com\",\n  \"password\": \"Password123!\"\n}"
-				},
-				"url": {
-					"raw": "{{host}}:{{port}}/api/auth/login",
-					"host": [
-						"{{host}}"
-					],
-					"port": "{{port}}",
-					"path": [
-						"api",
-						"auth",
-						"login"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Auth / Me (protected)",
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Authorization",
-						"value": "Bearer {{jwt}}"
-					}
-				],
-				"url": {
-					"raw": "{{host}}:{{port}}/api/me",
-					"host": [
-						"{{host}}"
-					],
-					"port": "{{port}}",
-					"path": [
-						"api",
-						"me"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Auth / Logout",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Authorization",
-						"value": "Bearer {{jwt}}"
-					}
-				],
-				"url": {
-					"raw": "{{host}}:{{port}}/api/auth/logout",
-					"host": [
-						"{{host}}"
-					],
-					"port": "{{port}}",
-					"path": [
-						"api",
-						"auth",
-						"logout"
-					]
-				}
-			},
-			"response": []
-		}
-	]
+        "info": {
+                "_postman_id": "b6e32813-0e6a-49df-9a33-26bdf266cf3f",
+                "name": "VideoRank API",
+                "description": "Colección básica para probar autenticación y salud del API de VideoRank.",
+                "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+                "_exporter_id": "31371962"
+        },
+        "item": [
+                {
+                        "name": "Health (status)",
+                        "request": {
+                                "method": "GET",
+                                "header": [],
+                                "url": {
+                                        "raw": "http://localhost:8080/status",
+                                        "protocol": "http",
+                                        "host": [
+                                                "localhost"
+                                        ],
+                                        "port": "8080",
+                                        "path": [
+                                                "status"
+                                        ]
+                                }
+                        },
+                        "response": []
+                },
+                {
+                        "name": "Health (health)",
+                        "request": {
+                                "method": "GET",
+                                "header": [],
+                                "url": {
+                                        "raw": "{{host}}:{{port}}/health",
+                                        "host": [
+                                                "{{host}}"
+                                        ],
+                                        "port": "{{port}}",
+                                        "path": [
+                                                "health"
+                                        ]
+                                }
+                        },
+                        "response": []
+                },
+                {
+                        "name": "Auth / Register",
+                        "request": {
+                                "method": "POST",
+                                "header": [
+                                        {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                        }
+                                ],
+                                "body": {
+                                        "mode": "raw",
+                                        "raw": "{\n  \"first_name\": \"Alice\",\n  \"last_name\": \"Tester\",\n  \"email\": \"alice@example.com\",\n  \"password1\": \"Password123!\",\n  \"password2\": \"Password123!\"\n}"
+                                },
+                                "url": {
+                                        "raw": "{{host}}:{{port}}/api/auth/signup",
+                                        "host": [
+                                                "{{host}}"
+                                        ],
+                                        "port": "{{port}}",
+                                        "path": [
+                                                "api",
+                                                "auth",
+                                                "signup"
+                                        ]
+                                }
+                        },
+                        "response": []
+                },
+                {
+                        "name": "Auth / Login",
+                        "event": [
+                                {
+                                        "listen": "test",
+                                        "script": {
+                                                "exec": [
+                                                        "// Guarda el token JWT en la variable de entorno 'jwt' si viene como { token_type: 'Bearer', expires_in: 3600, access_token: '...' }",
+                                                        "try {",
+                                                        "  const data = pm.response.json();",
+                                                        "  const token = data.token || data.access_token || data.jwt;",
+                                                        "  if (token) {",
+                                                        "    pm.environment.set('jwt', token);",
+                                                        "    console.log('JWT guardado en entorno');",
+                                                        "  } else {",
+                                                        "    console.warn('No se encontró token en la respuesta');",
+                                                        "  }",
+                                                        "} catch(e) {",
+                                                        "  console.error('No JSON o error parseando respuesta');",
+                                                        "}"
+                                                ],
+                                                "type": "text/javascript",
+                                                "packages": {}
+                                        }
+                                }
+                        ],
+                        "request": {
+                                "method": "POST",
+                                "header": [
+                                        {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                        }
+                                ],
+                                "body": {
+                                        "mode": "raw",
+                                        "raw": "{\n  \n  \"email\": \"alice@example.com\",\n  \"password\": \"Password123!\"\n}"
+                                },
+                                "url": {
+                                        "raw": "{{host}}:{{port}}/api/auth/login",
+                                        "host": [
+                                                "{{host}}"
+                                        ],
+                                        "port": "{{port}}",
+                                        "path": [
+                                                "api",
+                                                "auth",
+                                                "login"
+                                        ]
+                                }
+                        },
+                        "response": [
+                                {
+                                        "name": "Login exitoso",
+                                        "status": "OK",
+                                        "code": 200,
+                                        "header": [
+                                                {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                }
+                                        ],
+                                        "body": "{\n  \"token_type\": \"Bearer\",\n  \"expires_in\": 3600,\n  \"access_token\": \"<jwt>\"\n}"
+                                }
+                        ]
+                },
+                {
+                        "name": "Auth / Me (protected)",
+                        "request": {
+                                "method": "GET",
+                                "header": [
+                                        {
+                                                "key": "Authorization",
+                                                "value": "Bearer {{jwt}}"
+                                        }
+                                ],
+                                "url": {
+                                        "raw": "{{host}}:{{port}}/api/me",
+                                        "host": [
+                                                "{{host}}"
+                                        ],
+                                        "port": "{{port}}",
+                                        "path": [
+                                                "api",
+                                                "me"
+                                        ]
+                                }
+                        },
+                        "response": []
+                },
+                {
+                        "name": "Auth / Logout",
+                        "request": {
+                                "method": "POST",
+                                "header": [
+                                        {
+                                                "key": "Authorization",
+                                                "value": "Bearer {{jwt}}"
+                                        }
+                                ],
+                                "url": {
+                                        "raw": "{{host}}:{{port}}/api/auth/logout",
+                                        "host": [
+                                                "{{host}}"
+                                        ],
+                                        "port": "{{port}}",
+                                        "path": [
+                                                "api",
+                                                "auth",
+                                                "logout"
+                                        ]
+                                }
+                        },
+                        "response": []
+                }
+        ]
 }


### PR DESCRIPTION
## Summary
- return token duration alongside JWT in AuthService
- include token_type, expires_in and access_token in AuthHandlers Login response
- document new login contract in Postman collection

## Testing
- `cd Api && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b650c8e9e883258357a38881ac59e1