### PR TITLE
remove unique constraint on user first name

### DIFF
--- a/Api/internal/domain/entities/user.go
+++ b/Api/internal/domain/entities/user.go
@@ -4,7 +4,7 @@ import "time"
 
 type User struct {
 	UserId       uint   `gorm:"primaryKey"`
-	FirstName    string `gorm:"uniqueIndex;not null"`
+	FirstName    string `gorm:"not null"`
 	LastName     string `gorm:"not null"`
 	Email        string `gorm:"uniqueIndex;not null"`
 	PasswordHash string `gorm:"not null"`

--- a/Api/internal/infrastructure/migrations/0003_remove_firstname_unique.down.sql
+++ b/Api/internal/infrastructure/migrations/0003_remove_firstname_unique.down.sql
@@ -1,0 +1,2 @@
+-- Recreate unique index on users.first_name
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_first_name ON users(first_name);

--- a/Api/internal/infrastructure/migrations/0003_remove_firstname_unique.up.sql
+++ b/Api/internal/infrastructure/migrations/0003_remove_firstname_unique.up.sql
@@ -1,0 +1,4 @@
+-- Remove unique constraint or index from users.first_name
+ALTER TABLE users DROP CONSTRAINT IF EXISTS ux_users_first_name;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_first_name_key;
+DROP INDEX IF EXISTS idx_users_first_name;


### PR DESCRIPTION
## Summary
- remove unique index from `User.FirstName`
- drop existing unique constraint on `users.first_name`

## Testing
- `go fmt internal/domain/entities/user.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b6537442d483258301fd48a462f4de