### PR TITLE
Return BadRequest for duplicate registration email

### DIFF
--- a/Api/internal/presentation/auth.go
+++ b/Api/internal/presentation/auth.go
@@ -41,7 +41,7 @@ func (handler *AuthHandlers) Register(context *gin.Context) {
 		return
 	}
 	if exists {
-		context.JSON(http.StatusConflict, gin.H{"error": "email_already_in_use"})
+		context.JSON(http.StatusBadRequest, gin.H{"error": "email_already_in_use"})
 		return
 	}
 

--- a/Api/internal/presentation/auth_test.go
+++ b/Api/internal/presentation/auth_test.go
@@ -1,0 +1,47 @@
+package presentation
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"main_videork/internal/application/useCase"
+	"main_videork/internal/domain"
+	"main_videork/internal/domain/entities"
+)
+
+type mockUserRepo struct{}
+
+func (m *mockUserRepo) Create(ctx context.Context, user *entities.User) error {
+	return nil
+}
+
+func (m *mockUserRepo) GetByEmail(ctx context.Context, email string) (*entities.User, error) {
+	if email == "exists@example.com" {
+		return &entities.User{}, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+func TestAuthHandlers_RegisterEmailExists(t *testing.T) {
+	repo := &mockUserRepo{}
+	service := useCase.NewAuthService(repo, "secret")
+	handler := NewAuthHandlers(service)
+
+	router := gin.New()
+	router.POST("/api/auth/signup", handler.Register)
+
+	body := []byte(`{"first_name":"A","last_name":"B","email":"exists@example.com","password1":"p","password2":"p"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/signup", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected %d got %d", http.StatusBadRequest, w.Code)
+	}
+}

--- a/VideoRank API.postman_collection_OK.json
+++ b/VideoRank API.postman_collection_OK.json
@@ -24,7 +24,20 @@
                                         ]
                                 }
                         },
-                        "response": []
+                        "response": [
+                                {
+                                        "name": "Email ya registrado",
+                                        "status": "Bad Request",
+                                        "code": 400,
+                                        "header": [
+                                                {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                }
+                                        ],
+                                        "body": "{\n  \"error\": \"email_already_in_use\"\n}"
+                                }
+                        ]
                 },
                 {
                         "name": "Health (health)",
@@ -42,7 +55,9 @@
                                         ]
                                 }
                         },
-                        "response": []
+                        "response": [
+                                
+                        ]
                 },
                 {
                         "name": "Auth / Register",
@@ -71,7 +86,20 @@
                                         ]
                                 }
                         },
-                        "response": []
+                        "response": [
+                                {
+                                        "name": "Email ya registrado",
+                                        "status": "Bad Request",
+                                        "code": 400,
+                                        "header": [
+                                                {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                }
+                                        ],
+                                        "body": "{\n  \"error\": \"email_already_in_use\"\n}"
+                                }
+                        ]
                 },
                 {
                         "name": "Auth / Login",


### PR DESCRIPTION
## Summary
- use 400 Bad Request when a signup email already exists
- add regression test for duplicate email signup
- document 400 response in Postman collection

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b658dd31d483258d721384a75c3217