### PR TITLE
Add permission-based authorization middleware

### DIFF
--- a/Api/cmd/api/main.go
+++ b/Api/cmd/api/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	r := gin.Default()
 	r.Static("/static", "./static")
-	handlers.NewRouter(r, authService, userService, jwtSecret, uploadVideoUC)
+	handlers.NewRouter(r, authService, userService, userRepo, jwtSecret, uploadVideoUC)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/Api/internal/domain/interfaces/user_repository.go
+++ b/Api/internal/domain/interfaces/user_repository.go
@@ -9,4 +9,6 @@ import (
 type UserRepository interface {
 	Create(ctx context.Context, user *entities.User) error
 	GetByEmail(ctx context.Context, email string) (*entities.User, error)
+	// GetPermissions returns all privilege names assigned to the user through roles.
+	GetPermissions(ctx context.Context, userID uint) ([]string, error)
 }

--- a/Api/internal/infrastructure/repository/user_repository_imp.go
+++ b/Api/internal/infrastructure/repository/user_repository_imp.go
@@ -34,3 +34,18 @@ func (r *userRepository) GetByEmail(ctx context.Context, email string) (*entitie
 	}
 	return &user, nil
 }
+
+func (r *userRepository) GetPermissions(ctx context.Context, userID uint) ([]string, error) {
+	var perms []string
+	err := r.db.WithContext(ctx).
+		Table("privilege p").
+		Select("DISTINCT p.name").
+		Joins("JOIN role_privilege rp ON rp.privilege_id = p.privilege_id").
+		Joins("JOIN user_role ur ON ur.role_id = rp.role_id").
+		Where("ur.user_id = ?", userID).
+		Scan(&perms).Error
+	if err != nil {
+		return nil, err
+	}
+	return perms, nil
+}

--- a/Api/internal/presentation/handlers/router.go
+++ b/Api/internal/presentation/handlers/router.go
@@ -2,13 +2,14 @@ package handlers
 
 import (
 	"main_videork/internal/application/useCase"
+	"main_videork/internal/domain/interfaces"
 	"main_videork/internal/presentation/middlewares"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
-func NewRouter(router *gin.Engine, authService *useCase.AuthService, userService *useCase.UserService, secret string, uploadVideoUC *useCase.UploadVideoUseCase) {
+func NewRouter(router *gin.Engine, authService *useCase.AuthService, userService *useCase.UserService, userRepo interfaces.UserRepository, secret string, uploadVideoUC *useCase.UploadVideoUseCase) {
 	authHandlers := NewAuthHandlers(authService)
 	userHandlers := NewUserHandlers(userService)
 	videoHandlers := NewVideoHandlers(uploadVideoUC)
@@ -25,6 +26,9 @@ func NewRouter(router *gin.Engine, authService *useCase.AuthService, userService
 	authGroup.GET("/api/me", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
-	authGroup.POST("/api/videos/upload", videoHandlers.Upload)
+
+	videoGroup := authGroup.Group("/api/videos")
+	videoGroup.Use(middlewares.PermissionMiddleware(userRepo, "upload_video"))
+	videoGroup.POST("/upload", videoHandlers.Upload)
 
 }


### PR DESCRIPTION
## Summary
- add UserRepository.GetPermissions to fetch privileges
- implement PermissionMiddleware to enforce route-specific permissions
- apply upload_video permission on video upload route

## Testing
- `go test ./internal/...` *(fails: no test files)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cf5e939083258f9b044ef04e50fd