### PR TITLE
Store permissions in JWT and validate in handlers

### DIFF
--- a/Api/cmd/api/main.go
+++ b/Api/cmd/api/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	r := gin.Default()
 	r.Static("/static", "./static")
-	handlers.NewRouter(r, authService, userService, userRepo, jwtSecret, uploadVideoUC)
+	handlers.NewRouter(r, authService, userService, jwtSecret, uploadVideoUC)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/Api/internal/presentation/handlers/router.go
+++ b/Api/internal/presentation/handlers/router.go
@@ -2,14 +2,13 @@ package handlers
 
 import (
 	"main_videork/internal/application/useCase"
-	"main_videork/internal/domain/interfaces"
 	"main_videork/internal/presentation/middlewares"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
-func NewRouter(router *gin.Engine, authService *useCase.AuthService, userService *useCase.UserService, userRepo interfaces.UserRepository, secret string, uploadVideoUC *useCase.UploadVideoUseCase) {
+func NewRouter(router *gin.Engine, authService *useCase.AuthService, userService *useCase.UserService, secret string, uploadVideoUC *useCase.UploadVideoUseCase) {
 	authHandlers := NewAuthHandlers(authService)
 	userHandlers := NewUserHandlers(userService)
 	videoHandlers := NewVideoHandlers(uploadVideoUC)
@@ -28,7 +27,6 @@ func NewRouter(router *gin.Engine, authService *useCase.AuthService, userService
 	})
 
 	videoGroup := authGroup.Group("/api/videos")
-	videoGroup.Use(middlewares.PermissionMiddleware(userRepo, "upload_video"))
 	videoGroup.POST("/upload", videoHandlers.Upload)
 
 }

--- a/Api/internal/presentation/handlers/video_handler.go
+++ b/Api/internal/presentation/handlers/video_handler.go
@@ -41,6 +41,28 @@ func (h *VideoHandlers) Upload(c *gin.Context) {
 		return
 	}
 
+	permsVal, ok := c.Get("permissions")
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "permissions missing in context"})
+		return
+	}
+	perms, ok := permsVal.([]string)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid permissions in context"})
+		return
+	}
+	allowed := false
+	for _, p := range perms {
+		if p == "upload_video" {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
 	statusIDStr := c.PostForm("status_id")
 	statusID, err := strconv.ParseUint(statusIDStr, 10, 64)
 	if err != nil || statusID == 0 {


### PR DESCRIPTION
## Summary
- Include user permissions in JWT claims during login
- Parse permissions from JWT and attach to request context
- Enforce `upload_video` permission directly inside the video upload handler and simplify routing

## Testing
- `go test ./...` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5bfc6ab48325b70930e6909c577c