### PR TITLE
Add RabbitMQ integration for asynchronous video processing support

### DIFF
--- a/Api/go.mod
+++ b/Api/go.mod
@@ -5,6 +5,7 @@ go 1.24.3
 require (
 	github.com/Eyevinn/mp4ff v0.49.0
 	github.com/jackc/pgx/v5 v5.7.5
+	github.com/streadway/amqp v1.1.0
 )
 
 require github.com/minio/minio-go/v7 v7.0.95

--- a/Api/go.sum
+++ b/Api/go.sum
@@ -133,6 +133,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
+github.com/streadway/amqp v1.1.0 h1:py12iX8XSyI7aN/3dUT8DFIDJazNJsVJdxNVEpnQTZM=
+github.com/streadway/amqp v1.1.0/go.mod h1:WYSrTEYHOXHd0nwFeUXAe2G2hRnQT+deZJJf88uS9Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/Api/internal/domain/interfaces/messaging.go
+++ b/Api/internal/domain/interfaces/messaging.go
@@ -1,0 +1,8 @@
+package interfaces
+
+// MessagePublisher abstracts a message broker publisher.
+// Implemented in infra (e.g., RabbitMQPublisher).
+type MessagePublisher interface {
+	Publish(queue string, body []byte) error
+	Close() error
+}

--- a/Api/internal/infrastructure/messaging/rabbitmq_publisher.go
+++ b/Api/internal/infrastructure/messaging/rabbitmq_publisher.go
@@ -1,0 +1,89 @@
+package messaging
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/streadway/amqp"
+)
+
+// RabbitMQPublisher publishes messages to RabbitMQ queues.
+type RabbitMQPublisher struct {
+	conn    *amqp.Connection
+	channel *amqp.Channel
+}
+
+func NewRabbitMQPublisher(url string) (*RabbitMQPublisher, error) {
+	conn, err := amqp.Dial(url)
+	if err != nil {
+		return nil, err
+	}
+	ch, err := conn.Channel()
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	// Publisher confirms can be enabled later if needed
+	return &RabbitMQPublisher{conn: conn, channel: ch}, nil
+}
+
+// EnsureQueue declares a durable queue with optional DLX and max length.
+// It is safe to call multiple times; server will keep existing settings when compatible.
+func (p *RabbitMQPublisher) EnsureQueue(queueName string, maxLen int, withDLQ bool) error {
+	if withDLQ {
+		dlxName := queueName + ".dlx"
+		dlqName := queueName + ".dlq"
+		if err := p.channel.ExchangeDeclare(dlxName, "direct", true, false, false, false, nil); err != nil {
+			return err
+		}
+		if _, err := p.channel.QueueDeclare(dlqName, true, false, false, false, nil); err != nil {
+			return err
+		}
+		if err := p.channel.QueueBind(dlqName, queueName, dlxName, false, nil); err != nil {
+			return err
+		}
+		args := amqp.Table{
+			"x-dead-letter-exchange":    dlxName,
+			"x-dead-letter-routing-key": queueName,
+			"x-max-length":              maxLen,
+			"x-overflow":                "reject-publish-dlx",
+		}
+		if _, err := p.channel.QueueDeclare(queueName, true, false, false, false, args); err != nil {
+			return err
+		}
+		return nil
+	}
+	// Basic durable queue without DLX
+	_, err := p.channel.QueueDeclare(queueName, true, false, false, false, amqp.Table{"x-max-length": maxLen})
+	return err
+}
+
+// Publish sends a message with persistent delivery mode and application/json content-type.
+func (p *RabbitMQPublisher) Publish(queueName string, body []byte) error {
+	return p.channel.Publish("", queueName, false, false, amqp.Publishing{
+		DeliveryMode: amqp.Persistent,
+		ContentType:  "application/json",
+		Body:         body,
+	})
+}
+
+// PublishJSON marshals v to JSON and publishes it.
+func (p *RabbitMQPublisher) PublishJSON(queueName string, v interface{}) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return p.Publish(queueName, b)
+}
+
+func (p *RabbitMQPublisher) Close() error {
+	if p.channel != nil {
+		if err := p.channel.Close(); err != nil {
+			log.Printf("rabbitmq publisher channel close: %v", err)
+		}
+	}
+	if p.conn != nil {
+		return p.conn.Close()
+	}
+	return nil
+}

--- a/Api/internal/presentation/handlers/publico_handler.go
+++ b/Api/internal/presentation/handlers/publico_handler.go
@@ -74,8 +74,6 @@ func (h *PublicHandlers) VotePublicVideo(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Voto registrado exitosamente."})
 }
 
-// Unique violation mapping moved to repository layer; handler sees domain.ErrConflict only.
-
 // ListRankings maneja GET /api/public/rankings
 // Público, sin autenticación. Devuelve un array de RankingEntry.
 func (h *PublicHandlers) ListRankings(c *gin.Context) {

--- a/Api/internal/presentation/handlers/video_handler.go
+++ b/Api/internal/presentation/handlers/video_handler.go
@@ -17,9 +17,7 @@ import (
 	"github.com/google/uuid"
 )
 
-type VideoHandlers struct {
-	uploadsUC *useCase.UploadsUseCase
-}
+type VideoHandlers struct{ uploadsUC *useCase.UploadsUseCase }
 
 func NewVideoHandlers(uploadsUC *useCase.UploadsUseCase) *VideoHandlers {
 	return &VideoHandlers{uploadsUC: uploadsUC}
@@ -126,7 +124,9 @@ func (h *VideoHandlers) Upload(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid permissions in context"})
 		return
 	}
-	allowed := slices.Contains(perms, "upload_video")
+	// Align with OpenAPI: expect "videos:upload".
+	// Keep backward compatibility with legacy "upload_video".
+	allowed := slices.Contains(perms, "videos:upload") || slices.Contains(perms, "upload_video")
 	if !allowed {
 		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		return

--- a/Api/internal/presentation/handlers/video_handler_test.go
+++ b/Api/internal/presentation/handlers/video_handler_test.go
@@ -86,7 +86,7 @@ func TestListVideos_OK(t *testing.T) {
 		{VideoID: 1, UserID: 10, Title: "A", OriginalFile: "s3://orig/a.mp4", ProcessedFile: &processedURL, Status: string(entities.StatusProcessed), UploadedAt: now, ProcessedAt: &processed},
 		{VideoID: 2, UserID: 10, Title: "B", OriginalFile: "s3://orig/b.mp4", Status: string(entities.StatusUploaded), UploadedAt: now.Add(1 * time.Minute)},
 	}}
-	uc := useCase.NewUploadsUseCase(repo, &fakeStorage{})
+	uc := useCase.NewUploadsUseCase(repo, &fakeStorage{}, nil, "")
 	r := setupVideoRouter(uc, true)
 
 	w := httptest.NewRecorder()
@@ -113,7 +113,7 @@ func TestListVideos_OK(t *testing.T) {
 
 func TestListVideos_Empty(t *testing.T) {
 	repo := &fakeVideoRepo{list: []*entities.Video{}}
-	uc := useCase.NewUploadsUseCase(repo, &fakeStorage{})
+	uc := useCase.NewUploadsUseCase(repo, &fakeStorage{}, nil, "")
 	r := setupVideoRouter(uc, true)
 
 	w := httptest.NewRecorder()
@@ -134,7 +134,7 @@ func TestListVideos_Empty(t *testing.T) {
 
 func TestListVideos_RepoError(t *testing.T) {
 	repo := &fakeVideoRepo{err: errors.New("boom")}
-	uc := useCase.NewUploadsUseCase(repo, &fakeStorage{})
+	uc := useCase.NewUploadsUseCase(repo, &fakeStorage{}, nil, "")
 	r := setupVideoRouter(uc, true)
 
 	w := httptest.NewRecorder()
@@ -148,7 +148,7 @@ func TestListVideos_RepoError(t *testing.T) {
 
 func TestListVideos_Unauthorized(t *testing.T) {
 	repo := &fakeVideoRepo{}
-	uc := useCase.NewUploadsUseCase(repo, &fakeStorage{})
+	uc := useCase.NewUploadsUseCase(repo, &fakeStorage{}, nil, "")
 	r := setupVideoRouter(uc, false) // no auth middleware sets userID
 
 	w := httptest.NewRecorder()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,9 @@ services:
       MINIO_SECRET_KEY: minio12345
       MINIO_BUCKET: raw-videos-audio-removal
       MINIO_USE_SSL: "false"
+      # RabbitMQ to publish processing jobs
+      RABBITMQ_URL: amqp://admin:admin@rabbitmq:5672/
+      STATES_MACHINE_QUEUE: states_machine_queue
     restart: unless-stopped
     healthcheck:
       test: [ "CMD","wget","--no-verbose","--tries=1","--spider","http://localhost:8080/health" ]


### PR DESCRIPTION
- Added `MessagePublisher` interface and `RabbitMQPublisher` implementation to handle publishing messages to RabbitMQ queues.
- Integrated RabbitMQ publisher into `UploadsUseCase` to publish video processing tasks after successful uploads.
- Enhanced video uploads to generate unique file names, avoiding overwrites.
- Updated application initialization to set up RabbitMQ connections, declare queues with DLQ support, and pass publisher instances to use cases.
- Refactored related handlers, tests, and initialization logic to support the new messaging features.