### PR TITLE
Refactor error responses and add support for leaderboard and stats APIs

### DIFF
--- a/Api/internal/presentation/handlers/auth_handler.go
+++ b/Api/internal/presentation/handlers/auth_handler.go
@@ -20,12 +20,12 @@ func NewAuthHandlers(service *useCase.AuthService) *AuthHandlers {
 func (handler *AuthHandlers) Login(context *gin.Context) {
 	var request requests.LoginRequest
 	if err := context.ShouldBindJSON(&request); err != nil {
-		context.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		context.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request", "message": err.Error()})
 		return
 	}
 	token, expiresIn, err := handler.service.Login(context.Request.Context(), request.Email, request.Password)
 	if err != nil {
-		context.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		context.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized", "message": err.Error()})
 		return
 	}
 	context.JSON(http.StatusOK, gin.H{
@@ -39,16 +39,16 @@ func (handler *AuthHandlers) Logout(context *gin.Context) {
 	header := context.GetHeader("Authorization")
 	const prefix = "Bearer "
 	if header == "" || !strings.HasPrefix(header, prefix) {
-		context.JSON(http.StatusUnauthorized, gin.H{"error": "invalid authorization header"})
+		context.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized", "message": "invalid authorization header"})
 		return
 	}
 	token := strings.TrimSpace(header[len(prefix):])
 	if token == "" {
-		context.JSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+		context.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized", "message": "invalid token"})
 		return
 	}
 	if err := handler.service.Logout(token); err != nil {
-		context.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		context.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error", "message": err.Error()})
 		return
 	}
 	context.Status(http.StatusNoContent)

--- a/Api/internal/presentation/handlers/publico_handler.go
+++ b/Api/internal/presentation/handlers/publico_handler.go
@@ -74,7 +74,7 @@ func normalizeCityKey(s string) string {
 func (h *PublicHandlers) ListPublicVideos(c *gin.Context) {
 	results, err := h.service.ListPublicVideos(c.Request.Context())
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error", "message": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, results)
@@ -85,7 +85,7 @@ func (h *PublicHandlers) VotePublicVideo(c *gin.Context) {
 	// 1) Auth: extraer userID del contexto
 	userID := c.GetUint("userID")
 	if userID == 0 {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized", "message": "Token invalido o expirado."})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized", "message": invalidTokenExpiredMsg})
 		return
 	}
 

--- a/Api/internal/presentation/handlers/uploads_handler.go
+++ b/Api/internal/presentation/handlers/uploads_handler.go
@@ -29,7 +29,7 @@ func NewUploadsHandler(uploadsUC *useCase.UploadsUseCase) *UploadsHandlers {
 func (h *UploadsHandlers) UploadVideo(c *gin.Context) {
 	title := c.PostForm("title")
 	if title == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "title is required"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request", "message": "title is required"})
 		return
 	}
 	status := c.PostForm("status")
@@ -46,19 +46,19 @@ func (h *UploadsHandlers) UploadVideo(c *gin.Context) {
 		fh, err = c.FormFile("video_file")
 	}
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "video file is required"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request", "message": "video file is required"})
 		return
 	}
 
 	// Extract userID from Gin context
 	uidVal, ok := c.Get("userID")
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized", "message": invalidTokenExpiredMsg})
 		return
 	}
 	userID, ok := uidVal.(uint)
 	if !ok || userID == 0 {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized", "message": invalidTokenExpiredMsg})
 		return
 	}
 
@@ -73,10 +73,10 @@ func (h *UploadsHandlers) UploadVideo(c *gin.Context) {
 	})
 	if err != nil {
 		if errors.Is(err, domain.ErrInvalid) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request", "message": err.Error()})
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error", "message": err.Error()})
 		return
 	}
 

--- a/Api/internal/presentation/handlers/video_handler.go
+++ b/Api/internal/presentation/handlers/video_handler.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -48,7 +49,7 @@ func (h *VideoHandlers) ListVideos(c *gin.Context) {
 func (h *VideoHandlers) Upload(c *gin.Context) {
 	title := c.PostForm("title")
 	if title == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "title is required"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request", "message": "title is required"})
 		return
 	}
 
@@ -58,19 +59,24 @@ func (h *VideoHandlers) Upload(c *gin.Context) {
 		file, err = c.FormFile("video")
 	}
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "video file is required"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request", "message": "video file is required"})
 		return
 	}
 
-	// Validar MIME declarado
-	if ct := file.Header.Get("Content-Type"); ct != "video/mp4" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "mimeType must be video/mp4"})
+	// Validar MIME declarado: usar form field mimeType si viene; fallback a Content-Type del archivo.
+	// Si ninguno viene, aceptar por defecto (OpenAPI define default video/mp4).
+	mimeFromForm := strings.TrimSpace(c.PostForm("mimeType"))
+	if mimeFromForm == "" {
+		mimeFromForm = file.Header.Get("Content-Type")
+	}
+	if mimeFromForm != "" && mimeFromForm != "video/mp4" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request", "message": "mimeType must be video/mp4"})
 		return
 	}
 
 	// Validar tamaño declarado (=100MB)
 	if file.Size > validations.MaxBytes {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "file too large (max 100MB)"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request", "message": "file too large (max 100MB)"})
 		return
 	}
 
@@ -81,19 +87,19 @@ func (h *VideoHandlers) Upload(c *gin.Context) {
 
 	permsVal, ok := c.Get("permissions")
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "permissions missing in context"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized", "message": "permissions missing in context"})
 		return
 	}
 	perms, ok := permsVal.([]string)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid permissions in context"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized", "message": "invalid permissions in context"})
 		return
 	}
 	// Align with OpenAPI: expect "videos:upload".
 	// Keep backward compatibility with legacy "upload_video".
 	allowed := slices.Contains(perms, "videos:upload") || slices.Contains(perms, "upload_video")
 	if !allowed {
-		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		c.JSON(http.StatusForbidden, gin.H{"error": "Forbidden"})
 		return
 	}
 
@@ -109,10 +115,10 @@ func (h *VideoHandlers) Upload(c *gin.Context) {
 	output, err := h.uploadsUC.UploadMultipart(ctx, input)
 	if err != nil {
 		if errors.Is(err, domain.ErrInvalid) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request", "message": err.Error()})
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error", "message": err.Error()})
 		return
 	}
 

--- a/Api/openapi.yaml
+++ b/Api/openapi.yaml
@@ -18,6 +18,22 @@ tags:
 security:
   - bearerAuth: []
 paths:
+  /health:
+    get:
+      summary: Estado del servicio
+      description: Devuelve un estado simple para supervisión.
+      tags: [Público]
+      security: []
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+              example: { status: "ok" }
   /api/auth/signup:
     post:
       summary: Registro de nuevos jugadores
@@ -324,37 +340,7 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
 
-  /api/videos/{video_id}/file:
-    get:
-      summary: Descargar/servir archivo del video (privado)
-      description: Devuelve binario del **original** o **procesado** del dueño del video.
-      tags: [Videos]
-      security:
-        - bearerAuth: []
-      parameters:
-        - name: video_id
-          in: path
-          required: true
-          schema: { type: string }
-        - name: variant
-          in: query
-          required: false
-          schema:
-            type: string
-            enum: [original, processed]
-            default: processed
-          description: Variante a servir.
-      responses:
-        "200":
-          description: Binario del video.
-          content:
-            application/octet-stream:
-              schema:
-                type: string
-                format: binary
-        "401": { $ref: "#/components/responses/Unauthorized" }
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
+  
 
   /api/public/videos:
     get:
@@ -417,10 +403,6 @@ paths:
       responses:
         "200":
           description: Ranking actual.
-          headers:
-            X-Total-Count:
-              description: Total de elementos (si se pagina).
-              schema: { type: integer }
           content:
             application/json:
               schema:
@@ -437,6 +419,135 @@ paths:
                   city: Bogotá
                   votes: 1495
         "400": { $ref: "#/components/responses/BadRequest" }
+
+  /api/public/leaderboard/{poll_id}:
+    get:
+      summary: Leaderboard por encuesta (Redis)
+      description: Devuelve miembros y puntajes para un `poll_id`.
+      tags: [Ranking]
+      security: []
+      parameters:
+        - name: poll_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: city
+          in: query
+          required: false
+          schema: { type: string }
+          description: Filtrar por ciudad; forma parte de la clave.
+        - name: start
+          in: query
+          required: false
+          schema: { type: integer, minimum: 0, default: 0 }
+        - name: stop
+          in: query
+          required: false
+          schema: { type: integer, minimum: 0, default: 9 }
+      responses:
+        "200":
+          description: Rango del leaderboard.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    member: { type: string }
+                    score: { type: integer }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "503":
+          description: Agregados no configurados.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+              example: { error: "Service Unavailable", message: "Aggregates not configured" }
+        "500":
+          description: Error interno
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/public/stats/{poll_id}:
+    get:
+      summary: Estadísticas agregadas (Redis)
+      tags: [Ranking]
+      security: []
+      parameters:
+        - name: poll_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: city
+          in: query
+          required: false
+          schema: { type: string }
+      responses:
+        "200":
+          description: Estadísticas actuales.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total: { type: integer }
+                  last_ts: { type: integer }
+                  version: { type: integer }
+                  uniques: { type: integer }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "503":
+          description: Agregados no configurados.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+              example: { error: "Service Unavailable", message: "Aggregates not configured" }
+        "500":
+          description: Error interno
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /api/public/count/{poll_id}/{member}:
+    get:
+      summary: Puntaje de un miembro (Redis)
+      tags: [Ranking]
+      security: []
+      parameters:
+        - name: poll_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: member
+          in: path
+          required: true
+          schema: { type: string }
+        - name: city
+          in: query
+          required: false
+          schema: { type: string }
+      responses:
+        "200":
+          description: Puntaje actual del miembro.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  member: { type: string }
+                  score: { type: integer }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "503":
+          description: Agregados no configurados.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+              example: { error: "Service Unavailable", message: "Aggregates not configured" }
+        "500":
+          description: Error interno
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   
 
@@ -461,9 +572,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  city_id: { type: integer }
+                $ref: "#/components/schemas/CityIDResponse"
               example: { city_id: 123 }
         "400": { $ref: "#/components/responses/BadRequest" }
         "404": { $ref: "#/components/responses/NotFound" }
@@ -511,6 +620,10 @@ components:
       properties:
         error: { type: string }
         message: { type: string }
+    CityIDResponse:
+      type: object
+      properties:
+        city_id: { type: integer }
     SignupRequest:
       type: object
       required: [first_name, last_name, email, password1, password2, city, country]
@@ -573,11 +686,3 @@ components:
         username: { type: string }
         city: { type: string, nullable: true }
         votes: { type: integer, minimum: 0 }
-      required:
-        - key
-        - policy
-        - x-amz-algorithm
-        - x-amz-credential
-        - x-amz-date
-        - x-amz-signature
-        - Content-Type

--- a/VideoRank API.postman_collection_OK.json
+++ b/VideoRank API.postman_collection_OK.json
@@ -207,16 +207,15 @@
       "response": []
     },
     {
-      "name": "Videos / Download file (protected)",
+      "name": "Videos / Publish (protected)",
       "request": {
-        "method": "GET",
+        "method": "POST",
         "header": [ { "key": "Authorization", "value": "Bearer {{jwt}}" } ],
         "url": {
-          "raw": "{{host}}:{{port}}/api/videos/{{video_id}}/file?variant=processed",
+          "raw": "{{host}}:{{port}}/api/videos/{{video_id}}/publish",
           "host": ["{{host}}"],
           "port": "{{port}}",
-          "path": ["api","videos","{{video_id}}","file"],
-          "query": [ { "key": "variant", "value": "processed" } ],
+          "path": ["api","videos","{{video_id}}","publish"],
           "variable": [ { "key": "video_id", "value": "a1b2c3d4" } ]
         }
       },
@@ -265,6 +264,61 @@
             { "key": "city", "value": "" },
             { "key": "page", "value": "1" },
             { "key": "pageSize", "value": "20" }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Ranking / Leaderboard by poll_id",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{host}}:{{port}}/api/public/leaderboard/{{poll_id}}?city=&start=0&stop=9",
+          "host": ["{{host}}"],
+          "port": "{{port}}",
+          "path": ["api","public","leaderboard","{{poll_id}}"],
+          "query": [
+            { "key": "city", "value": "" },
+            { "key": "start", "value": "0" },
+            { "key": "stop", "value": "9" }
+          ],
+          "variable": [ { "key": "poll_id", "value": "default_poll" } ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Ranking / Stats by poll_id",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{host}}:{{port}}/api/public/stats/{{poll_id}}?city=",
+          "host": ["{{host}}"],
+          "port": "{{port}}",
+          "path": ["api","public","stats","{{poll_id}}"],
+          "query": [ { "key": "city", "value": "" } ],
+          "variable": [ { "key": "poll_id", "value": "default_poll" } ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Ranking / Count by poll_id/member",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{host}}:{{port}}/api/public/count/{{poll_id}}/{{member}}?city=",
+          "host": ["{{host}}"],
+          "port": "{{port}}",
+          "path": ["api","public","count","{{poll_id}}","{{member}}"],
+          "query": [ { "key": "city", "value": "" } ],
+          "variable": [
+            { "key": "poll_id", "value": "default_poll" },
+            { "key": "member", "value": "some_user" }
           ]
         }
       },


### PR DESCRIPTION
- Unified error responses across handlers by standardizing `error` and `message` fields.
- Added new endpoints for Redis-backed leaderboard, stats, and member-specific counts APIs.
- Updated OpenAPI documentation to include new endpoints and the `/health` check route.
- Enhanced video upload validation with `mimeType` fallback handling.
- Replaced `Download file` API with `Publish` API for videos and updated related swagger definitions.